### PR TITLE
Option for icon/text/both in status bar

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@
 
 # NOTE: The VERSION here is just used for the package name
 # Edit install.rdf and content/synonyms.js to change the actual VERSION
-VERSION=2.0.9
+VERSION=2.0.9g
 SRC_DIR=./src
 
 # Dest should be absolute or relative to SRC_DIR

--- a/src/content/Overlay.xul
+++ b/src/content/Overlay.xul
@@ -117,7 +117,6 @@
                   onclick="com.gContactSync.showLog();"
                   label="&initialStatus.label;"
                   image="chrome://gContactSync/skin/logo_main_16.png"
-                  class="statusbarpanel-iconic-text"
                   tooltiptext="&status.tooltip;"/>
   <menu id="gContactSyncMenu"
         label="&gContactSyncMenu.label;"

--- a/src/content/Overlay.xul
+++ b/src/content/Overlay.xul
@@ -116,6 +116,8 @@
   <statusbarpanel id="gContactSyncStatusText"
                   onclick="com.gContactSync.showLog();"
                   label="&initialStatus.label;"
+                  image="chrome://gContactSync/skin/logo_main_16.png"
+                  class="statusbarpanel-iconic-text"
                   tooltiptext="&status.tooltip;"/>
   <menu id="gContactSyncMenu"
         label="&gContactSyncMenu.label;"

--- a/src/content/Preferences.js
+++ b/src/content/Preferences.js
@@ -137,6 +137,13 @@ com.gContactSync.Preferences = {
           elem.label = pref.value;
         }
         break;
+      case "statusBarClass":
+        var elem = document.getElementById("gContactSyncStatusText");
+        if (elem) {
+	  com.gContactSync.LOGGER.LOG("Changing gContactSyncStatusText className '"+elem.className+"' -> '"+pref.value+"'");
+          elem.className = pref.value;
+        }
+        break;
       case "enableMenu":
         var elem = document.getElementById("gContactSyncMenu");
         if (elem) {
@@ -195,6 +202,7 @@ com.gContactSync.Preferences = {
     addReset:                 new com.gContactSync.Pref("addReset",                 "bool", true),
     alertSummary:             new com.gContactSync.Pref("alertSummary",             "bool", true),
     statusBarText:            new com.gContactSync.Pref("statusBarText",            "char", ""),
+    statusBarClass:           new com.gContactSync.Pref("statusBarClass",           "char", ""),
     myContactsName:           new com.gContactSync.Pref("myContactsName",           "char", "Contacts"),
     lastVersionMajor:         new com.gContactSync.Pref("lastVersionMajor",         "int",  0),
     lastVersionMinor:         new com.gContactSync.Pref("lastVersionMinor",         "int",  0),
@@ -308,9 +316,22 @@ com.gContactSync.Preferences = {
                                                    this.mTypes.CHAR));
       }
     }
+    // collapse gContactSyncMenu if !enableMenu
     if (!com.gContactSync.Preferences.mSyncPrefs.enableMenu.value &&
           document.getElementById("gContactSyncMenu")) {
       document.getElementById("gContactSyncMenu").collapsed = true;
+    }
+    // adjust statusbarpanel's class with saved preference
+    { var sbpanel = document.getElementById("gContactSyncStatusText");
+      if (sbpanel) {
+        if (com.gContactSync.Preferences.mSyncPrefs.statusBarClass.value) {
+	  com.gContactSync.LOGGER.LOG("Set gContactSyncStatusText className to '"+com.gContactSync.Preferences.mSyncPrefs.statusBarClass.value+"'");
+	  sbpanel.className = com.gContactSync.Preferences.mSyncPrefs.statusBarClass.value;
+	} else {
+	  com.gContactSync.LOGGER.LOG("Unset gContactSyncStatusText className");
+	  sbpanel.className = "";
+	}
+      }
     }
   },
   /**

--- a/src/content/options.xul
+++ b/src/content/options.xul
@@ -173,6 +173,9 @@
       <preference id="addReset"
                   name="extensions.gContactSync.addReset"
                   type="bool"/>
+      <preference id="statusBarClass"
+                  name="extensions.gContactSync.statusBarClass"
+                  type="string"/>
       <preference id="phoneColLabels"
                   name="extensions.gContactSync.phoneColLabels"
                   type="bool"/>
@@ -192,6 +195,16 @@
                   id="addReset"
                   label="&addReset.label;"
                   accesskey="&addReset.accesskey;"/>
+      </groupbox>
+      <groupbox id="statusBarClass">
+         <caption label="&statusBarClass.label;"/>
+         <radiogroup preference="statusBarClass"
+                  orient="horizontal"
+                  >
+          <radio id="sb-icon-only" value="statusbarpanel-iconic" label="&statusBarClass.icon.label;" accesskey="&statusBarClass.icon.accesskey;"/>
+          <radio id="sb-text-only" selected="true" value="" label="&statusBarClass.text.label;" accesskey="&statusBarClass.text.accesskey;"/>
+          <radio id="sb-both" value="statusbarpanel-iconic-text" label="&statusBarClass.both.label;" accesskey="&statusBarClass.both.accesskey;"/>
+         </radiogroup>
       </groupbox>
       <groupbox>
         <caption label="&abResults.label;"/>

--- a/src/content/synonyms.js
+++ b/src/content/synonyms.js
@@ -49,7 +49,7 @@ com.gContactSync.versionMajor   = "2";
 /** The minor version of gContactSync (ie 3 in 0.3.0b1) */
 com.gContactSync.versionMinor   = "0";
 /** The release for the current version of gContactSync (ie 1 in 0.3.1a7) */
-com.gContactSync.versionRelease = "9";
+com.gContactSync.versionRelease = "9g";
 /** The suffix for the current version of gContactSync (ie a7 for Alpha 7) */
 com.gContactSync.versionSuffix  = "";
 /** The attribute where the dummy e-mail address is stored */

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -3,7 +3,7 @@
      xmlns:em="http://www.mozilla.org/2004/em-rdf#">
     <Description about="urn:mozilla:install-manifest">
         <em:id>gContactSync@pirules.net</em:id>
-        <em:version>2.0.9</em:version>
+        <em:version>2.0.9g</em:version>
         <em:name>gContactSync</em:name>
         <em:description>Synchronizes Google Contacts with Thunderbird</em:description>
         <em:creator>Josh Geenen</em:creator>

--- a/src/locale/en-US/options.dtd
+++ b/src/locale/en-US/options.dtd
@@ -37,6 +37,13 @@
 <!ENTITY enableMenuLinks.accesskey        "l">
 <!ENTITY addReset.label                   "Add Replace to and Replace from Server links to the Address Book context menu">
 <!ENTITY addReset.accesskey               "A">
+<!ENTITY statusBarClass.label                   "Status bar">
+<!ENTITY statusBarClass.icon.label                   "icon">
+<!ENTITY statusBarClass.icon.accesskey                   "i">
+<!ENTITY statusBarClass.text.label                   "text">
+<!ENTITY statusBarClass.text.accesskey                   "t">
+<!ENTITY statusBarClass.both.label                   "both">
+<!ENTITY statusBarClass.both.accesskey                   "b">
 <!ENTITY abResults.label                  "Contacts List">
 <!ENTITY phoneColLabels.label             "Rename the phone column labels">
 <!ENTITY phoneColLabels.accesskey         "R">

--- a/src/locale/es-ES/options.dtd
+++ b/src/locale/es-ES/options.dtd
@@ -35,6 +35,13 @@
 <!ENTITY enableMenuLinks.accesskey "l">
 <!ENTITY addReset.label "Agergar enlaces Reemplazar a y Reemplazar desde servidor al menú contextual del al Libreta de Direcciones">
 <!ENTITY addReset.accesskey "R">
+<!ENTITY statusBarClass.label                   "Barra de estado">
+<!ENTITY statusBarClass.icon.label                   "ícono">
+<!ENTITY statusBarClass.icon.accesskey                   "i">
+<!ENTITY statusBarClass.text.label                   "texto">
+<!ENTITY statusBarClass.text.accesskey                   "t">
+<!ENTITY statusBarClass.both.label                   "ambos">
+<!ENTITY statusBarClass.both.accesskey                   "b">
 <!ENTITY abResults.label "Lista de Contactos">
 <!ENTITY phoneColLabels.label "Renombrar las etiquetas de la columna teléfono">
 <!ENTITY phoneColLabels.accesskey "R">

--- a/src/locale/pt-PT/options.dtd
+++ b/src/locale/pt-PT/options.dtd
@@ -35,6 +35,13 @@
 <!ENTITY enableMenuLinks.accesskey "l">
 <!ENTITY addReset.label "Adicionar \'Substituir para\' e \'Substituir a partir so Servidor\' ao menu de contexto no Livro de Endereços">
 <!ENTITY addReset.accesskey "S">
+<!ENTITY statusBarClass.label                   "Barra de estado">
+<!ENTITY statusBarClass.icon.label                   "ícone">
+<!ENTITY statusBarClass.icon.accesskey                   "i">
+<!ENTITY statusBarClass.text.label                   "texto">
+<!ENTITY statusBarClass.text.accesskey                   "t">
+<!ENTITY statusBarClass.both.label                   "ambos">
+<!ENTITY statusBarClass.both.accesskey                   "b">
 <!ENTITY abResults.label "Lista de Contactos">
 <!ENTITY phoneColLabels.label "Mudar o nome das etiquetas da coluna telefone">
 <!ENTITY phoneColLabels.accesskey "M">


### PR DESCRIPTION
Hello gContactSync team,

Good job with this addon ! very usefull ! Thanks !

As I have a status bar with many things, and sometime status message are a little long, I prefer just the icon in the status bar.
So I add an option to choose between text/icon or both in the status bar. I update the Spanish and Partuguese locale (French will come in another branch...).
(Nota: the first commit is just to change the version number)

I hope you accept this little interface modification.

Best regards,

Greg