### PR TITLE
add check to skip init() of gContactSync

### DIFF
--- a/src/content/CardDialogOverlay.js
+++ b/src/content/CardDialogOverlay.js
@@ -117,6 +117,11 @@ gContactSync.CardDialogOverlay = {
       gContactSync.CardDialogOverlay.mLoadNumber++;
       return;
     }
+
+    //the XUL injected all extra elements as hidden, unhide them
+    document.getElementById("gContactSyncTab").hidden = false;
+    document.getElementById("anniversaryField").hidden = false;
+    
     for (var i = 0; i < gContactSync.Preferences.mSyncPrefs.numRelations.value; ++i) {
       gContactSync.gAttributes["Relation" + i] = "";
       gContactSync.gAttributes["Relation" + i + "Type"] = "";

--- a/src/content/CardDialogOverlay.js
+++ b/src/content/CardDialogOverlay.js
@@ -85,6 +85,30 @@ gContactSync.CardDialogOverlay = {
    * loaded.
    */
   init: function CardDialogOverlay_init() {
+    //check string property of directory, if init() of gContactSync should be skipped
+    let arg = window.arguments[0];
+    let abURI = "";
+    let gContactSyncSkipped = "";
+    //newCardDialog and editCardDialog use different names for the ab argument
+    if (arg.hasOwnProperty("abURI")) {
+        abURI = arg.abURI;
+    } else if (arg.hasOwnProperty("selectedAB")) {
+        abURI = arg.selectedAB;
+    }
+
+    if (abURI) {
+        let abManager = Components.classes["@mozilla.org/abmanager;1"].getService(Components.interfaces.nsIAbManager);
+        let ab = abManager.getDirectory(abURI);
+        try {
+            gContactSyncSkipped = ab.getStringValue("gContactSyncSkipped", "");
+        } catch (e) {} 
+    }
+    
+    if (gContactSyncSkipped) {
+      return;
+    }
+
+
     // if it isn't finished loading yet wait another 200 ms and try again
     if (!document.getElementById("abTabs")) {
       // if it has tried to load more than 50 times something is wrong, so quit

--- a/src/content/CardDialogOverlay.xul
+++ b/src/content/CardDialogOverlay.xul
@@ -71,13 +71,13 @@
   </stringbundleset>
   
   <tabs id="abTabs">
-    <tab label="&gContactSyncTab.label;"     id="gContactSyncTab"/>
+    <tab label="&gContactSyncTab.label;" hidden="true" id="gContactSyncTab"/>
   </tabs>
 
   <tabpanels id="abTabPanels" flex="1">
 
     <vbox id="abHomeTab">
-      <hbox id="anniversaryField" align="center" after="birthdayField">
+      <hbox id="anniversaryField" align="center" after="birthdayField" hidden="true">
         <spacer flex="1"/>
         <label control="Anniversary" value="&Anniversary.label;"
                accesskey="&Anniversary.accesskey;"/>


### PR DESCRIPTION
This is John from last weeks email regarding the UI clash with TbSync. Thanks for your friendly response.

This PR adds a little check to skip the init() of gContactSync.CardDialogOverlay, if the directory of that card has certain flag set. All TbSync directories will have that flag set :-).

In my view, stopping init() from being executed is even better, than trying to role back what init() has done.

